### PR TITLE
rename let object to fix conflict reported by minitest

### DIFF
--- a/test/lines_test.rb
+++ b/test/lines_test.rb
@@ -12,8 +12,8 @@ class LinesTest < StatusTest
   end
 
   describe "#to_s" do
-    let (:output) { "1\n2" }
-    it { Nit::Lines.new(output).to_s.must_equal(output) }
+    let (:out) { "1\n2" }
+    it { Nit::Lines.new(out).to_s.must_equal(out) }
   end
 
   describe "Line" do


### PR DESCRIPTION
Without this fix I'm getting

```
/Users/jetbrains/.rvm/rubies/ruby-2.2.2/bin/ruby -e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift) /Users/jetbrains/.rvm/rubies/ruby-2.2.2/bin/rake test
Testing started at 14:22 ...
/Users/jetbrains/.rvm/rubies/ruby-2.2.2/bin/ruby -I"lib:test"  "/Users/jetbrains/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/status_test.rb" "test/commands_test.rb" "test/config_test.rb" "test/files_test.rb" "test/ignore_test.rb" "test/lines_test.rb" "test/nit_test.rb" "test/status_test.rb" 
/Users/jetbrains/.rvm/gems/ruby-2.2.2@rails/gems/minitest-5.6.1/lib/minitest/spec.rb:239:in `let': let 'output' cannot override a method in Minitest::Spec. Please use another name. (ArgumentError)
    from /Users/jetbrains/RubymineProjects/nit/test/lines_test.rb:15:in `block in <class:LinesTest>'
    from /Users/jetbrains/.rvm/gems/ruby-2.2.2@rails/gems/minitest-5.6.1/lib/minitest/spec.rb:80:in `class_eval'
    from /Users/jetbrains/.rvm/gems/ruby-2.2.2@rails/gems/minitest-5.6.1/lib/minitest/spec.rb:80:in `describe'
    from /Users/jetbrains/RubymineProjects/nit/test/lines_test.rb:14:in `<class:LinesTest>'
    from /Users/jetbrains/RubymineProjects/nit/test/lines_test.rb:1:in `<top (required)>'
    from /Users/jetbrains/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/jetbrains/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /Users/jetbrains/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:15:in `block in <main>'
    from /Users/jetbrains/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:4:in `select'
    from /Users/jetbrains/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb:4:in `<main>'
rake aborted!
Command failed with status (1): [ruby -I"lib:test"  "/Users/jetbrains/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/status_test.rb" "test/commands_test.rb" "test/config_test.rb" "test/files_test.rb" "test/ignore_test.rb" "test/lines_test.rb" "test/nit_test.rb" "test/status_test.rb" ]
-e:1:in `load'
-e:1:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

when trying to run tests
